### PR TITLE
✨ Feat: 강의평 등록 시 강의 검색 기능 추가

### DIFF
--- a/src/main/java/com/example/UMC8th_MiniProject/domain/Review.java
+++ b/src/main/java/com/example/UMC8th_MiniProject/domain/Review.java
@@ -10,7 +10,6 @@ import java.math.BigDecimal;
 @Entity
 @Table(name = "Review")
 @AttributeOverride(name = "createdAt", column = @Column(name = "created_at"))
-@AttributeOverride(name = "updatedAt", column = @Column(name = "updated_at"))
 @Getter
 @AllArgsConstructor
 @Builder
@@ -40,4 +39,8 @@ public class Review extends BaseEntity {
     private Integer likes = 0;
 
     private String imgUrl;
+
+    public void increaseLikes() {
+        this.likes = this.likes + 1;
+    }
 }

--- a/src/main/java/com/example/UMC8th_MiniProject/service/reviewService/ReviewService.java
+++ b/src/main/java/com/example/UMC8th_MiniProject/service/reviewService/ReviewService.java
@@ -1,7 +1,9 @@
 package com.example.UMC8th_MiniProject.service.reviewService;
 
-import com.example.UMC8th_MiniProject.repository.ReviewRepository;
+import com.example.UMC8th_MiniProject.domain.Lecture;
 import com.example.UMC8th_MiniProject.domain.Review;
+import com.example.UMC8th_MiniProject.repository.LectureRepository;
+import com.example.UMC8th_MiniProject.repository.ReviewRepository;
 import com.example.UMC8th_MiniProject.repository.ReviewSpecification;
 import com.example.UMC8th_MiniProject.web.dto.review.ReviewFilterRequestDTO;
 import com.example.UMC8th_MiniProject.web.dto.review.ReviewResponse;
@@ -23,6 +25,7 @@ import java.util.stream.Collectors;
 public class ReviewService {
 
     private final ReviewRepository reviewRepository;
+    private final LectureRepository lectureRepository;
 
     public List<ReviewResponse.SearchReviewResponse> reviewFilter(ReviewFilterRequestDTO filterRequestDTO, Integer pageNumber, Integer type){
 
@@ -58,6 +61,36 @@ public class ReviewService {
                 .content(review.getContent())
                 .imageUrl(review.getImgUrl())
                 .createdAt(review.getCreatedAt())
+                .build();
+    }
+
+    @Transactional
+    public ReviewResponse.LikeResponse increaseLikes(Long reviewId) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new RuntimeException("리뷰를 찾을 수 없습니다."));
+
+        review.increaseLikes();
+
+        return ReviewResponse.LikeResponse.builder()
+                .reviewId(reviewId)
+                .currentLikes(review.getLikes())
+                .build();
+    }
+
+    public List<ReviewResponse.LectureSearchResponse> searchLecturesForReview(String keyword) {
+        List<Lecture> lectures = lectureRepository.findByNameContaining(keyword);
+
+        return lectures.stream()
+                .map(this::toLectureSearchDTO)
+                .collect(Collectors.toList());
+    }
+
+    private ReviewResponse.LectureSearchResponse toLectureSearchDTO(Lecture lecture) {
+        return ReviewResponse.LectureSearchResponse.builder()
+                .lectureId(lecture.getLectureId())
+                .name(lecture.getName())
+                .teacher(lecture.getTeacher())
+                .platform(lecture.getPlatform())
                 .build();
     }
 }

--- a/src/main/java/com/example/UMC8th_MiniProject/web/controller/ReviewController.java
+++ b/src/main/java/com/example/UMC8th_MiniProject/web/controller/ReviewController.java
@@ -44,4 +44,22 @@ public class ReviewController {
         List<ReviewResponse.SearchReviewResponse> result = reviewService.reviewFilter(filterDto, pageNumber,2);
         return ApiResponse.onSuccess(result);
     }
+
+    @Operation(summary = "리뷰 좋아요 API", description = "특정 리뷰에 좋아요를 누르는 API입니다.")
+    @PostMapping("/{reviewId}/like")
+    public ApiResponse<ReviewResponse.LikeResponse> likeReview(
+            @PathVariable Long reviewId) {
+
+        ReviewResponse.LikeResponse result = reviewService.increaseLikes(reviewId);
+        return ApiResponse.onSuccess(result);
+    }
+
+    @Operation(summary = "리뷰 등록 시 강의 검색 API", description = "리뷰 등록 시 입력할 강의를 검색합니다. lectureId, name, teacher, platform을 반환합니다.")
+    @GetMapping("/lecture/search")
+    public ApiResponse<List<ReviewResponse.LectureSearchResponse>> searchLecturesForReview(
+            @Parameter(description = "강의 키워드") @RequestParam String keyword) {
+
+        List<ReviewResponse.LectureSearchResponse> result = reviewService.searchLecturesForReview(keyword);
+        return ApiResponse.onSuccess(result);
+    }
 }

--- a/src/main/java/com/example/UMC8th_MiniProject/web/dto/review/ReviewResponse.java
+++ b/src/main/java/com/example/UMC8th_MiniProject/web/dto/review/ReviewResponse.java
@@ -1,5 +1,6 @@
 package com.example.UMC8th_MiniProject.web.dto.review;
 
+import com.example.UMC8th_MiniProject.domain.enums.Platform;
 import com.example.UMC8th_MiniProject.domain.enums.StudyTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,5 +22,23 @@ public class ReviewResponse {
         String content;
         String imageUrl;
         LocalDateTime createdAt;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class LikeResponse {
+        Long reviewId;
+        Integer currentLikes;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class LectureSearchResponse {
+        Long lectureId;
+        String name;
+        String teacher;
+        Platform platform;
     }
 }


### PR DESCRIPTION
## 작업 내용

> 키워드를 검색하면 그 키워드를 가지고 있는 모든 강의가 리스트로 보입니다.
id, 강의명, 강사명, 플랫폼 정보를 포함하고 있습니다.
ex) 강의명 a, 디자인 a가 있다면, a 검색 시 a와 디자인 a가 보입니다.

## 참고 사항

> 브랜치 생성 및 push 과정에서 오류가 생기는 바람에 어쩔 수 없이 브랜치 17 내역을 수동으로 옮기게 되었습니다.

## 연관 이슈
<br>
