### PR TITLE
✨ Feat: 강의평 검색 기능 추가

### DIFF
--- a/src/main/java/com/example/UMC8th_MiniProject/domain/Review.java
+++ b/src/main/java/com/example/UMC8th_MiniProject/domain/Review.java
@@ -10,7 +10,6 @@ import java.math.BigDecimal;
 @Entity
 @Table(name = "Review")
 @AttributeOverride(name = "createdAt", column = @Column(name = "created_at"))
-@AttributeOverride(name = "updatedAt", column = @Column(name = "updated_at"))
 @Getter
 @AllArgsConstructor
 @Builder
@@ -40,4 +39,8 @@ public class Review extends BaseEntity {
     private Integer likes = 0;
 
     private String imgUrl;
+
+    public void increaseLikes() {
+        this.likes = this.likes + 1;
+    }
 }

--- a/src/main/java/com/example/UMC8th_MiniProject/domain/Review.java
+++ b/src/main/java/com/example/UMC8th_MiniProject/domain/Review.java
@@ -10,6 +10,7 @@ import java.math.BigDecimal;
 @Entity
 @Table(name = "Review")
 @AttributeOverride(name = "createdAt", column = @Column(name = "created_at"))
+@AttributeOverride(name = "updatedAt", column = @Column(name = "updated_at"))
 @Getter
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/example/UMC8th_MiniProject/repository/ReviewSpecification.java
+++ b/src/main/java/com/example/UMC8th_MiniProject/repository/ReviewSpecification.java
@@ -19,4 +19,8 @@ public class ReviewSpecification {
     public static Specification<Review> hasStudyTime(StudyTime studyTime) {
         return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("studyTime"), studyTime);
     }
+
+    public static Specification<Review> contentContains(String keyword) {
+        return (root, query, cb) -> cb.like(root.get("content"), "%" + keyword + "%");
+    }
 }

--- a/src/main/java/com/example/UMC8th_MiniProject/service/reviewService/ReviewSearchService.java
+++ b/src/main/java/com/example/UMC8th_MiniProject/service/reviewService/ReviewSearchService.java
@@ -1,0 +1,52 @@
+package com.example.UMC8th_MiniProject.service.reviewService;
+
+import com.example.UMC8th_MiniProject.domain.Review;
+import com.example.UMC8th_MiniProject.repository.ReviewRepository;
+import com.example.UMC8th_MiniProject.repository.ReviewSpecification;
+import com.example.UMC8th_MiniProject.web.dto.review.ReviewResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewSearchService {
+
+    private final ReviewRepository reviewRepository;
+
+    public List<ReviewResponse.SearchReviewResponse> searchReviewsByKeyword(
+            String keyword, Integer pageNumber, Integer size, String sortBy, String direction) {
+
+        Specification<Review> spec = Specification.where(ReviewSpecification.contentContains(keyword));
+
+        Sort.Direction sortDirection = "asc".equalsIgnoreCase(direction) ? Sort.Direction.ASC : Sort.Direction.DESC;
+        Pageable pageable = PageRequest.of(pageNumber, size, Sort.by(sortDirection, sortBy));
+
+        Page<Review> reviews = reviewRepository.findAll(spec, pageable);
+
+        return reviews.stream()
+                .map(this::toSearchDTO)
+                .collect(Collectors.toList());
+    }
+
+    private ReviewResponse.SearchReviewResponse toSearchDTO(Review review) {
+        return ReviewResponse.SearchReviewResponse.builder()
+                .reviewId(review.getReviewId())
+                .rate(review.getRating())
+                .studyTime(review.getStudyTime())
+                .likes(review.getLikes())
+                .content(review.getContent())
+                .imageUrl(review.getImgUrl())
+                .createdAt(review.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/UMC8th_MiniProject/service/reviewService/ReviewService.java
+++ b/src/main/java/com/example/UMC8th_MiniProject/service/reviewService/ReviewService.java
@@ -1,7 +1,9 @@
 package com.example.UMC8th_MiniProject.service.reviewService;
 
-import com.example.UMC8th_MiniProject.repository.ReviewRepository;
+import com.example.UMC8th_MiniProject.domain.Lecture;
 import com.example.UMC8th_MiniProject.domain.Review;
+import com.example.UMC8th_MiniProject.repository.LectureRepository;
+import com.example.UMC8th_MiniProject.repository.ReviewRepository;
 import com.example.UMC8th_MiniProject.repository.ReviewSpecification;
 import com.example.UMC8th_MiniProject.web.dto.review.ReviewFilterRequestDTO;
 import com.example.UMC8th_MiniProject.web.dto.review.ReviewResponse;
@@ -23,6 +25,7 @@ import java.util.stream.Collectors;
 public class ReviewService {
 
     private final ReviewRepository reviewRepository;
+    private final LectureRepository lectureRepository;
 
     public List<ReviewResponse.SearchReviewResponse> reviewFilter(ReviewFilterRequestDTO filterRequestDTO, Integer pageNumber, Integer type){
 
@@ -58,6 +61,36 @@ public class ReviewService {
                 .content(review.getContent())
                 .imageUrl(review.getImgUrl())
                 .createdAt(review.getCreatedAt())
+                .build();
+    }
+
+    @Transactional
+    public ReviewResponse.LikeResponse increaseLikes(Long reviewId) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new RuntimeException("리뷰를 찾을 수 없습니다."));
+
+        review.increaseLikes();
+
+        return ReviewResponse.LikeResponse.builder()
+                .reviewId(reviewId)
+                .currentLikes(review.getLikes())
+                .build();
+    }
+
+    public List<ReviewResponse.LectureSearchResponse> searchLecturesForReview(String keyword) {
+        List<Lecture> lectures = lectureRepository.findByNameContaining(keyword);
+
+        return lectures.stream()
+                .map(this::toLectureSearchDTO)
+                .collect(Collectors.toList());
+    }
+
+    private ReviewResponse.LectureSearchResponse toLectureSearchDTO(Lecture lecture) {
+        return ReviewResponse.LectureSearchResponse.builder()
+                .lectureId(lecture.getLectureId())
+                .name(lecture.getName())
+                .teacher(lecture.getTeacher())
+                .platform(lecture.getPlatform())
                 .build();
     }
 }

--- a/src/main/java/com/example/UMC8th_MiniProject/web/controller/ReviewController.java
+++ b/src/main/java/com/example/UMC8th_MiniProject/web/controller/ReviewController.java
@@ -44,4 +44,22 @@ public class ReviewController {
         List<ReviewResponse.SearchReviewResponse> result = reviewService.reviewFilter(filterDto, pageNumber,2);
         return ApiResponse.onSuccess(result);
     }
+
+    @Operation(summary = "리뷰 좋아요 API", description = "특정 리뷰에 좋아요를 누르는 API입니다.")
+    @PostMapping("/{reviewId}/like")
+    public ApiResponse<ReviewResponse.LikeResponse> likeReview(
+            @PathVariable Long reviewId) {
+
+        ReviewResponse.LikeResponse result = reviewService.increaseLikes(reviewId);
+        return ApiResponse.onSuccess(result);
+    }
+
+    @Operation(summary = "리뷰 등록 시 강의 검색 API", description = "리뷰 등록 시 입력할 강의를 검색합니다. lectureId, name, teacher, platform을 반환합니다.")
+    @GetMapping("/lecture/search")
+    public ApiResponse<List<ReviewResponse.LectureSearchResponse>> searchLecturesForReview(
+            @Parameter(description = "강의 키워드") @RequestParam String keyword) {
+
+        List<ReviewResponse.LectureSearchResponse> result = reviewService.searchLecturesForReview(keyword);
+        return ApiResponse.onSuccess(result);
+    }
 }

--- a/src/main/java/com/example/UMC8th_MiniProject/web/controller/ReviewController.java
+++ b/src/main/java/com/example/UMC8th_MiniProject/web/controller/ReviewController.java
@@ -1,13 +1,14 @@
 package com.example.UMC8th_MiniProject.web.controller;
 
 import com.example.UMC8th_MiniProject.apiPayload.ApiResponse;
+import com.example.UMC8th_MiniProject.converter.TofilterDtoConverter;
 import com.example.UMC8th_MiniProject.domain.enums.Category;
 import com.example.UMC8th_MiniProject.domain.enums.Level;
 import com.example.UMC8th_MiniProject.domain.enums.StudyTime;
+import com.example.UMC8th_MiniProject.service.reviewService.ReviewSearchService;
 import com.example.UMC8th_MiniProject.service.reviewService.ReviewService;
 import com.example.UMC8th_MiniProject.web.dto.review.ReviewFilterRequestDTO;
 import com.example.UMC8th_MiniProject.web.dto.review.ReviewResponse;
-import com.example.UMC8th_MiniProject.converter.TofilterDtoConverter;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.constraints.Min;
@@ -22,6 +23,7 @@ import java.util.List;
 public class ReviewController {
 
     private final ReviewService reviewService;
+    private final ReviewSearchService reviewSearchService;
 
     @Operation(summary = "popular 탭 강의 인기순 조회 API", description = "popular 탭 강의 조회 API입니다. 기본으로 인기순 조회되며, 파라미터 값으로 옵션 넘겨주세요. 페이지는 0부터 시작합니다.")
     @GetMapping("/latest")
@@ -60,6 +62,25 @@ public class ReviewController {
             @Parameter(description = "강의 키워드") @RequestParam String keyword) {
 
         List<ReviewResponse.LectureSearchResponse> result = reviewService.searchLecturesForReview(keyword);
+        return ApiResponse.onSuccess(result);
+    }
+
+    @Operation(summary = "리뷰 검색 API", description = "키워드로 리뷰를 검색합니다. reviewId, rate, content, studyTime, likes, imgurl, createdAt을 반환합니다.")
+    @GetMapping("/search")
+    public ApiResponse<List<ReviewResponse.SearchReviewResponse>> searchReviews(
+            @Parameter(description = "리뷰 내용 키워드") @RequestParam String keyword,
+            @Parameter(description = "정렬 기준 (rating, createdAt, likes)")
+            @RequestParam(defaultValue = "rating") String sortBy,
+            @Parameter(description = "정렬 방향 (asc, desc)")
+            @RequestParam(defaultValue = "desc") String direction,
+            @Parameter(description = "페이지 번호 (0부터 시작)")
+            @RequestParam(defaultValue = "0") @Min(0) Integer pageNumber,
+            @Parameter(description = "페이지 크기")
+            @RequestParam(defaultValue = "5") Integer size) {
+
+        List<ReviewResponse.SearchReviewResponse> result =
+                reviewSearchService.searchReviewsByKeyword(keyword, pageNumber, size, sortBy, direction);
+
         return ApiResponse.onSuccess(result);
     }
 }

--- a/src/main/java/com/example/UMC8th_MiniProject/web/dto/review/ReviewFilterRequestDTO.java
+++ b/src/main/java/com/example/UMC8th_MiniProject/web/dto/review/ReviewFilterRequestDTO.java
@@ -14,4 +14,5 @@ public class ReviewFilterRequestDTO {
     Category category;
     Level level;
     StudyTime studyTime;
+    String keyword;
 }

--- a/src/main/java/com/example/UMC8th_MiniProject/web/dto/review/ReviewResponse.java
+++ b/src/main/java/com/example/UMC8th_MiniProject/web/dto/review/ReviewResponse.java
@@ -1,5 +1,6 @@
 package com.example.UMC8th_MiniProject.web.dto.review;
 
+import com.example.UMC8th_MiniProject.domain.enums.Platform;
 import com.example.UMC8th_MiniProject.domain.enums.StudyTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,5 +22,23 @@ public class ReviewResponse {
         String content;
         String imageUrl;
         LocalDateTime createdAt;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class LikeResponse {
+        Long reviewId;
+        Integer currentLikes;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class LectureSearchResponse {
+        Long lectureId;
+        String name;
+        String teacher;
+        Platform platform;
     }
 }


### PR DESCRIPTION
## 작업 내용

> 키워드를 입력하면 해당 키워드를 content에 가지고 있는 모든 리뷰가 보입니다.
디자인에 나와있는 평점을 디폴트 정렬 기준으로 삼았습니다. 
평점말고 뭐가 있는지 안 나와있지만 필터링에 인기순이 있어서 좋아요, 평점, 날짜 세 가지를 정렬 기준으로 설정했습니다.
반환 데이터는rating, content, studyTime, likes, created_at 입니다

## 참고 사항

> 엔드 포인트가 reviews/search라서 searchController가 있긴 하지만 ReviewController에 추가했습니다.
그리고 제가 실수로 review의 updated_at을 지웠더라구요. created_at이 2개 있는 줄 알았어요... 리뷰 수정 기능이 없는 것 같지만 일단 다시 살려놨습니다.

## 연관 이슈

> #18 #20 


<br>
